### PR TITLE
Added one-step ctor to MessageVar and fixed API validation error in sendTemplate()

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApi.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApi.java
@@ -63,8 +63,8 @@ public final class MandrillMessagesApi {
 	 * in the user's account; <b>Required</b>.
 	 * @param templateContent An map of template content to send. 
 	 * Each entry in the map should have the name of the content 
-	 * block to set the content for, and the actual content 
-	 * to put into the block.
+	 * block to set the content for, corresponding to an mc:edit block,
+	 * and the actual content to put into the block.  May be null.
 	 * @param m The other information on the message to send &ndash; 
 	 * same as {@link #messagesSend(MandrillMessage, Boolean)}, but 
 	 * without the html content.
@@ -92,9 +92,12 @@ public final class MandrillMessagesApi {
 		params.put("template_name", templateName);
 		final ArrayList<TemplateContent> contents;
 		if(templateContent == null) {
-			contents = null;
-		} else {
-			contents = new ArrayList<MandrillMessagesApi.TemplateContent>(
+            contents = new ArrayList<MandrillMessagesApi.TemplateContent>(1);
+            // API requires at least one entry in the template_content array, even when unused
+            contents.add( TemplateContent.create("satisfy_validation", "") );
+        }
+        else {
+            contents = new ArrayList<MandrillMessagesApi.TemplateContent>(
 					templateContent.size());
 			for(String name : templateContent.keySet()) {
 				contents.add( TemplateContent.create(

--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessage.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessage.java
@@ -639,6 +639,22 @@ public class MandrillMessage {
 		private String name, content;
 
 		/**
+		 * Construct a MergeVar.
+		 */
+		public MergeVar() {
+		}
+
+		/**
+		 * Construct and assign name and content in one step.
+		 * @param name The merge variable's name
+		 * @param content The merge variable's content.
+		 */
+		public MergeVar(final String name, final String content) {
+			this.name = name;
+			this.content = content;
+		}
+
+		/**
 		 * @return The merge variable's name. 
 		 * Merge variable names are case-insensitive 
 		 * and may not start with _ (underline).


### PR DESCRIPTION
Users of the API can now add a mergeVar to a list like so:
<code>mergeVars.add(new MergeVar("name", "value"))</code>

Also, I was getting API validation errors calling sendTemplate() with no template_content.  It turns out that the validator requires a value there, even if it is empty.
