### PR TITLE
Converted MandrillMessageStatus.status to enum

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/LutungGsonUtils.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/LutungGsonUtils.java
@@ -5,6 +5,7 @@ package com.microtripit.mandrillapp.lutung.model;
 
 import com.google.gson.*;
 import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
+import com.microtripit.mandrillapp.lutung.view.MandrillMessageStatus;
 
 import java.lang.reflect.Type;
 import java.text.ParseException;
@@ -35,7 +36,8 @@ public final class LutungGsonUtils {
 				.setDateFormat(dateFormatStr)
 				.registerTypeAdapter(Date.class, new DateDeserializer())
 				.registerTypeAdapter(Map.class, new MapSerializer())
-                .registerTypeAdapter(MandrillMessage.Recipient.Type.class, new RecipientTypeSerializer());
+				.registerTypeAdapter(MandrillMessage.Recipient.Type.class, new RecipientTypeSerializer())
+				.registerTypeAdapter(MandrillMessageStatus.Status.class, new MessageStatusSerializer());
 	}
 	
 	public static final class DateDeserializer 
@@ -113,4 +115,27 @@ public final class LutungGsonUtils {
 			return new JsonPrimitive(src.name().toLowerCase());
 		}
 	}
+
+	public static final class MessageStatusSerializer
+			implements JsonDeserializer<MandrillMessageStatus.Status>, JsonSerializer<MandrillMessageStatus.Status> {
+
+		public final MandrillMessageStatus.Status deserialize(final JsonElement json,
+																final Type typeOfT, final JsonDeserializationContext context)
+				throws JsonParseException {
+			if(!json.isJsonPrimitive()) {
+				throw new JsonParseException(
+						"Unexpected type for recipient type: " +json.toString());
+			}
+
+			return MandrillMessageStatus.Status.valueOf(json.getAsString().toUpperCase());
+
+		}
+
+		public JsonPrimitive serialize(MandrillMessageStatus.Status src, Type typeOfSrc,
+									   JsonSerializationContext context) {
+
+			return new JsonPrimitive(src.name().toLowerCase());
+		}
+	}
+
 }

--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessage.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessage.java
@@ -572,7 +572,7 @@ public class MandrillMessage {
 	 */
 	public static class Recipient {
 		public enum Type {
-			TO, BCC, CC;
+			TO, BCC, CC
 		}
 
 		private String email, name;

--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessageStatus.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessageStatus.java
@@ -9,7 +9,13 @@ package com.microtripit.mandrillapp.lutung.view;
  * @since Mar 16, 2013
  */
 public class MandrillMessageStatus {
-	private String email, status, reject_reason, _id;
+	public enum Status {
+		SENT, QUEUED, SCHEDULED, REJECTED, INVALID
+	}
+
+
+	private String email, reject_reason, _id;
+	private Status status;
 
 	/**
 	 * @return The email address of the recipient.
@@ -19,10 +25,9 @@ public class MandrillMessageStatus {
 	}
 
 	/**
-	 * @return The sending status of the recipient &ndash; 
-	 * either 'sent', 'queued', 'rejected', or 'invalid'.
+	 * @return The sending status of the recipient
 	 */
-	public String getStatus() {
+	public Status getStatus() {
 		return status;
 	}
 	


### PR DESCRIPTION
This should result in early detection of mandrill api changes. It also
allows to use switch on status values in pre-1.7 java.

New enum values are:
SENT, QUEUED, SCHEDULED, REJECTED, INVALID

Removed unnecesarry semicolon from MandrilMessage.Recipient.Type
