### PR TITLE
suggested changes to accept normal JVM proxy parameters to the Apache HT...

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillUtil.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillUtil.java
@@ -4,7 +4,13 @@
 package com.microtripit.mandrillapp.lutung.controller;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import com.microtripit.mandrillapp.lutung.model.MandrillApiError;
@@ -25,6 +31,25 @@ final class MandrillUtil {
 	protected static final HashMap<String,Object> paramsWithKey(final String key) {
 		final HashMap<String,Object> params = new HashMap<String,Object>();
 		params.put("key",key);
+		List l = null;
+		try {
+		    l = ProxySelector.getDefault().select(new URI(rootUrl));
+		} 
+		catch (URISyntaxException e) {
+		    e.printStackTrace();
+		}
+		if (l != null) {
+		    for (Iterator iter = l.iterator(); iter.hasNext();) {
+		    	java.net.Proxy proxy = (java.net.Proxy) iter.next();
+
+		    	InetSocketAddress addr = (InetSocketAddress) proxy.address();
+
+		    	if (addr != null){
+		    		params.put("http.proxyHost",addr.getHostName());
+		    		params.put("http.proxyPort", Integer.toString(addr.getPort()));
+		    	}
+		    }
+		}
 		return params;
 	}
 	

--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequest.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequest.java
@@ -42,6 +42,10 @@ public final class MandrillRequest<OUT> implements RequestModel<OUT> {
 		return url;
 	}
 
+	public final Map<String, ? extends Object> getRequestParams(){
+		return requestParams;
+	}
+
 	public final HttpRequestBase getRequest() throws IOException {
 		final String paramsStr = LutungGsonUtils.getGson().toJson(
 				requestParams, requestParams.getClass());

--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
@@ -9,9 +9,11 @@ import java.io.InputStream;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
+import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.params.CoreProtocolPNames;
 import org.apache.http.util.EntityUtils;
@@ -36,8 +38,13 @@ public final class MandrillRequestDispatcher {
 				client = new DefaultHttpClient();
 				client.getParams().setParameter(
 						CoreProtocolPNames.USER_AGENT, 
-						client.getParams().getParameter(CoreProtocolPNames.USER_AGENT)
-						+ "/Lutung-0.1");
+						client.getParams().getParameter(CoreProtocolPNames.USER_AGENT)+ "/Lutung-0.1");
+				String proxyHost = (String) requestModel.getRequestParams().get("http.proxyHost");
+				String proxyPort = (String) requestModel.getRequestParams().get("http.proxyPort");
+				if(proxyHost != null && proxyPort != null){
+					HttpHost proxy = new HttpHost(proxyHost,Integer.parseInt(proxyPort));
+					client.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY,proxy);
+				}
 			}
 			if(log.isDebugEnabled()) {
 				log.debug("starting request '" +requestModel.getUrl()+ "'");

--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/RequestModel.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/RequestModel.java
@@ -5,6 +5,7 @@ package com.microtripit.mandrillapp.lutung.model;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 
 import org.apache.http.client.methods.HttpRequestBase;
 
@@ -20,6 +21,11 @@ public interface RequestModel<V> {
 	 * @return The url for this request, as {@link String}.
 	 */
 	public String getUrl();
+
+	/**
+	 * @return The requestParameters, as {@link Map<String, ? extends Object>}.
+	 */
+	public Map<String, ? extends Object> getRequestParams();
 	
 	/**
 	 * @return The request object describing the request to 


### PR DESCRIPTION
suggested changes to accept normal JVM proxy parameters to the Apache HTTP connector:

This allows the applications to be run with parameters like 
JAVA_OPTS = -Dhttp.proxyHost="hardcoreproxy.com" -Dhttp.proxyPort=8080 and still work.
Otherwise this nice API hangs with a connection timeout when behind a proxy.

Please review and let me know if you think there is a better solution or if any of the code is ugly in any way :). Thanks for the API !!
