### PR TITLE
Fixed the parse mandrill api URL to the correct location.

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApi.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApi.java
@@ -312,7 +312,7 @@ public class MandrillMessagesApi {
 		
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("raw_message", rawMessage);
-		return MandrillUtil.query(rootUrl+ "messages/send.json", 
+		return MandrillUtil.query(rootUrl+ "messages/parse.json",
 				params, MandrillMessage.class);
 		
 	}

--- a/src/test/java/com/microtripit/mandrillapp/lutung/MandrillTestCase.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/MandrillTestCase.java
@@ -51,15 +51,15 @@ public abstract class MandrillTestCase {
 			is.close();
 			if(apikey == null || apikey.isEmpty()) {
 				throw new IOException("Empty file 'myapikey.txt'");
-				
+
 			}
 			return apikey;
-			
+
 		} catch(final IOException e) {
 			log.error("No Mandrill API key defined - " +
 					"please provide your Mandrill API key!", e);
 			return null;
-			
+
 		}
 	}
 	

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApiTest.java
@@ -99,4 +99,21 @@ public final class MandrillMessagesApiTest extends MandrillTestCase {
             Assert.assertNotNull( content );
         }
     }
+
+	@Test
+	public void testParse01() throws IOException, MandrillApiError {
+		String testUnparsedMsg = "From: sender@example.com\n" +
+				"To: recipient.email@example.com\n" +
+				"Subject: Lutang test subject\n\n" +
+				"Sup mandrill !";
+		MandrillMessage parsedMessage = mandrillApi.messages().parse(testUnparsedMsg);
+		Assume.assumeNotNull(parsedMessage);
+		Assert.assertEquals("Lutang test subject", parsedMessage.getSubject());
+	}
+
+	@Test(expected = MandrillApiError.class)
+	public void testParse02() throws IOException, MandrillApiError {
+		MandrillMessage parsedMessage = mandrillApi.messages().parse(null);
+		Assert.fail();
+	}
 }


### PR DESCRIPTION
The URL from the parse() api call was mistaken with the send() api call url