### PR TITLE
Addition of template labels support:

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillTemplatesApi.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillTemplatesApi.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.controller;
 
@@ -21,7 +21,7 @@ import com.microtripit.mandrillapp.lutung.view.MandrillTimeSeries;
 public class MandrillTemplatesApi {
 	private static final String rootUrl = MandrillUtil.rootUrl;
 	private final String key;
-	
+
 	public MandrillTemplatesApi(final String key) {
 		this.key = key;
 	}
@@ -29,44 +29,64 @@ public class MandrillTemplatesApi {
 	/**
 	 * <p>Add a new template.</p>
 	 * @param name The name for the new template - must be unique.
-	 * @param code The HTML code for the template with mc:edit 
+	 * @param code The HTML code for the template with mc:edit
 	 * attributes for the editable elements.
-	 * @param publish Set to false to add a draft template 
+	 * @param publish Set to false to add a draft template
 	 * without publishing.
 	 * @return The information saved about the new template.
 	 * @throws MandrillApiError
 	 * @throws IOException
 	 */
-	public MandrillTemplate add(final String name, 
-			final String code, final Boolean publish) 
+	public MandrillTemplate add(final String name,
+			final String code, final Boolean publish)
 					throws MandrillApiError, IOException {
-		
-		return add(name, null, null, null, code, null, publish);
-		
+
+		return add(name, null, null, null, code, null, publish, null);
+
 	}
-	
+
 	/**
 	 * <p>Add a new template.</p>
 	 * @param name The name for the new template - must be unique.
-	 * @param fromEmail A default sending address for emails 
+	 * @param code The HTML code for the template with mc:edit
+	 * attributes for the editable elements.
+	 * @param publish Set to false to add a draft template
+	 * without publishing.
+	 * @return The information saved about the new template.
+	 * @throws MandrillApiError
+	 * @throws IOException
+	 */
+	public MandrillTemplate add(final String name,
+			final String code, final Boolean publish, String[] labels)
+					throws MandrillApiError, IOException {
+
+		return add(name, null, null, null, code, null, publish, labels);
+
+	}
+
+	/**
+	 * <p>Add a new template.</p>
+	 * @param name The name for the new template - must be unique.
+	 * @param fromEmail A default sending address for emails
 	 * sent using this template.
 	 * @param fromName A default from name to be used.
 	 * @param subject A default subject line to be used.
-	 * @param code The HTML code for the template with mc:edit 
+	 * @param code The HTML code for the template with mc:edit
 	 * attributes for the editable elements.
-	 * @param text A default text part to be used when 
+	 * @param text A default text part to be used when
 	 * sending with this template.
-	 * @param publish Set to false to add a draft template 
+	 * @param publish Set to false to add a draft template
 	 * without publishing.
+	 * @param labels Strings associated with the template
 	 * @return The information saved about the new template.
 	 * @throws MandrillApiError
 	 * @throws IOException
 	 */
 	public MandrillTemplate add(final String name, final String fromEmail,
-			final String fromName, final String subject, final String code, 
-			final String text, final Boolean publish) 
+			final String fromName, final String subject, final String code,
+			final String text, final Boolean publish, String[] labels)
 					throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("name", name);
 		params.put("from_email", fromEmail);
@@ -75,11 +95,12 @@ public class MandrillTemplatesApi {
 		params.put("code", code);
 		params.put("text", text);
 		params.put("publish", publish);
-		return MandrillUtil.query(rootUrl+ "templates/add.json", 
+		params.put("labels", labels);
+		return MandrillUtil.query(rootUrl+ "templates/add.json",
 				params, MandrillTemplate.class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Get the information for an existing template.</p>
 	 * @param name The immutable name of an existing template.
@@ -87,55 +108,75 @@ public class MandrillTemplatesApi {
 	 * @throws MandrillApiError
 	 * @throws IOException
 	 */
-	public MandrillTemplate info(final String name) 
+	public MandrillTemplate info(final String name)
 			throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("name", name);
-		return MandrillUtil.query(rootUrl+ "templates/info.json", 
+		return MandrillUtil.query(rootUrl+ "templates/info.json",
 				params, MandrillTemplate.class);
-		
+
 	}
-	
+
 	/**
-	 * <p>Update the code for an existing template.</p> 
+	 * <p>Update the code for an existing template.</p>
 	 * @param name The immutable name of an existing template.
 	 * @param code The new code for the template.
-	 * @param publish Set to false to update the draft 
+	 * @param publish Set to false to update the draft
 	 * version of the template without publishing.
 	 * @return The updated template.
 	 * @throws MandrillApiError
 	 * @throws IOException
 	 */
-	public MandrillTemplate update(final String name, 
-			final String code, final Boolean publish) 
+	public MandrillTemplate update(final String name,
+			final String code, final Boolean publish)
 					throws MandrillApiError, IOException {
-		
-		return update(name, null, null, null, code, null, publish);
-		
+
+		return update(name, null, null, null, code, null, publish, null);
+
 	}
-	
+
 	/**
-	 * <p>Update the code for an existing template.</p> 
+	 * <p>Update the code for an existing template.</p>
 	 * @param name The immutable name of an existing template.
-	 * @param fromEmail A default sending address for emails 
+	 * @param code The new code for the template.
+	 * @param publish Set to false to update the draft
+	 * version of the template without publishing.
+	 * @param labels Strings associated with the template
+	 * @return The updated template.
+	 * @throws MandrillApiError
+	 * @throws IOException
+	 */
+	public MandrillTemplate update(final String name,
+			final String code, final Boolean publish, String[] labels)
+					throws MandrillApiError, IOException {
+
+		return update(name, null, null, null, code, null, publish, labels);
+
+	}
+
+	/**
+	 * <p>Update the code for an existing template.</p>
+	 * @param name The immutable name of an existing template.
+	 * @param fromEmail A default sending address for emails
 	 * sent using this template.
 	 * @param fromName A default from name to be used.
 	 * @param subject A default subject line to be used.
 	 * @param code The new code for the template.
-	 * @param text A default text part to be used when 
+	 * @param text A default text part to be used when
 	 * sending with this template.
-	 * @param publish Set to false to update the draft 
+	 * @param publish Set to false to update the draft
 	 * version of the template without publishing.
+	 * @param labels Strings associated with the template
 	 * @return The updated template.
 	 * @throws MandrillApiError
 	 * @throws IOException
 	 */
-	public MandrillTemplate update(final String name, 
-			final String fromEmail, final String fromName, 
-			final String subject, final String code, final String text, 
-			final Boolean publish) throws MandrillApiError, IOException {
-		
+	public MandrillTemplate update(final String name,
+			final String fromEmail, final String fromName,
+			final String subject, final String code, final String text,
+			final Boolean publish, String[] labels) throws MandrillApiError, IOException {
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("name", name);
 		params.put("from_email", fromEmail);
@@ -144,30 +185,31 @@ public class MandrillTemplatesApi {
 		params.put("code", code);
 		params.put("text", text);
 		params.put("publish", publish);
-		return MandrillUtil.query(rootUrl+ "templates/update.json", 
+		params.put("labels", labels);
+		return MandrillUtil.query(rootUrl+ "templates/update.json",
 				params, MandrillTemplate.class);
-		
+
 	}
-	
+
 	/**
-	 * <p>Publish the content for the template. Any new messages 
-	 * sent using this template will start using the content 
+	 * <p>Publish the content for the template. Any new messages
+	 * sent using this template will start using the content
 	 * that was previously in draft.</p>
 	 * @param name The immutable name of an existing template.
 	 * @return The published template.
 	 * @throws MandrillApiError
 	 * @throws IOException
 	 */
-	public MandrillTemplate publish(final String name) 
+	public MandrillTemplate publish(final String name)
 			throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("name", name);
-		return MandrillUtil.query(rootUrl+ "templates/publish.json", 
+		return MandrillUtil.query(rootUrl+ "templates/publish.json",
 				params, MandrillTemplate.class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Delete a template.</p>
 	 * @param name The immutable name of an existing template.
@@ -175,77 +217,97 @@ public class MandrillTemplatesApi {
 	 * @throws MandrillApiError
 	 * @throws IOException
 	 */
-	public MandrillTemplate delete(final String name) 
+	public MandrillTemplate delete(final String name)
 			throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("name", name);
-		return MandrillUtil.query(rootUrl+ "templates/delete.json", 
+		return MandrillUtil.query(rootUrl+ "templates/delete.json",
 				params, MandrillTemplate.class);
-		
+
 	}
-	
+
 	/**
 	 * <p>Get a list of all the templates available to this user.</p>
-	 * @return An array of {@link MandrillTemplate} objects with 
+	 * @return An array of {@link MandrillTemplate} objects with
 	 * information about each template.
 	 * @throws MandrillApiError
 	 * @throws IOException
 	 */
-	public MandrillTemplate[] list() 
+	public MandrillTemplate[] list()
 			throws MandrillApiError, IOException {
-		
+
 		return MandrillUtil.query(
-				rootUrl+ "templates/list.json", 
-				MandrillUtil.paramsWithKey(key), 
+				rootUrl+ "templates/list.json",
+				MandrillUtil.paramsWithKey(key),
 				MandrillTemplate[].class);
-		
+
 	}
-	
+
 	/**
-	 * <p>Get the recent history (hourly stats for the last 
+	 * <p>Get a list of all the templates available to this user.</p>
+	 * @param label String associated with the template
+	 * @return An array of {@link MandrillTemplate} objects with
+	 * information about each template.
+	 * @throws MandrillApiError
+	 * @throws IOException
+	 */
+	public MandrillTemplate[] list(String label)
+			throws MandrillApiError, IOException {
+
+		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
+		params.put("label", label);
+
+		return MandrillUtil.query(
+				rootUrl+ "templates/list.json",
+				params,
+				MandrillTemplate[].class);
+	}
+
+	/**
+	 * <p>Get the recent history (hourly stats for the last
 	 * 30 days) for a template.</p>
 	 * @param name The immutable name of an existing template.
-	 * @return An array of {@link MandrillTimeSeries} objects 
+	 * @return An array of {@link MandrillTimeSeries} objects
 	 * containing stats from the history of this template.
 	 * @throws MandrillApiError
 	 * @throws IOException
 	 */
-	public MandrillTimeSeries[] timeSeries(final String name) 
+	public MandrillTimeSeries[] timeSeries(final String name)
 			throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("name", name);
-		return MandrillUtil.query(rootUrl+ "templates/time-series.json", 
+		return MandrillUtil.query(rootUrl+ "templates/time-series.json",
 				params, MandrillTimeSeries[].class);
-		
+
 	}
-	
+
 	/**
-	 * <p>Inject content and optionally merge fields into 
+	 * <p>Inject content and optionally merge fields into
 	 * a template, returning the HTML that results.</p>
 	 * @param name The immutable name of an existing template.
-	 * @param templateContent A map of template content to render. 
-	 * Each item in the map is used as key (name): the name of the 
-	 * content block to set the content for, and value (content): 
+	 * @param templateContent A map of template content to render.
+	 * Each item in the map is used as key (name): the name of the
+	 * content block to set the content for, and value (content):
 	 * the actual content to put into the block.
-	 * @param mergeVars Optional merge variables to use for injecting 
-	 * merge field content. If this is not provided, no merge fields 
+	 * @param mergeVars Optional merge variables to use for injecting
+	 * merge field content. If this is not provided, no merge fields
 	 * will be replaced.
-	 * @return The result of rendering the given template with the 
+	 * @return The result of rendering the given template with the
 	 * content and merge field values injected.
 	 * @throws MandrillApiError
 	 * @throws IOException
 	 */
-	public String render(final String name, 
-			final Map<String,String> templateContent, 
-			final Map<String,String> mergeVars) 
+	public String render(final String name,
+			final Map<String,String> templateContent,
+			final Map<String,String> mergeVars)
 					throws MandrillApiError, IOException {
-		
+
 		final HashMap<String,Object> params = MandrillUtil.paramsWithKey(key);
 		params.put("template_name", name);
 		if(templateContent != null && !templateContent.isEmpty()) {
-			final ArrayList<MandrillContentWrapper> contents = 
+			final ArrayList<MandrillContentWrapper> contents =
 					new ArrayList<MandrillContentWrapper>(templateContent.size());
 			for(String cName : templateContent.keySet()) {
 				contents.add( MandrillContentWrapper.create(
@@ -254,7 +316,7 @@ public class MandrillTemplatesApi {
 			params.put("template_content", contents);
 		}
 		if(mergeVars != null && !mergeVars.isEmpty()) {
-			final ArrayList<MandrillContentWrapper> vars = 
+			final ArrayList<MandrillContentWrapper> vars =
 					new ArrayList<MandrillContentWrapper>(mergeVars.size());
 			for(String cName : mergeVars.keySet()) {
 				vars.add( MandrillContentWrapper.create(
@@ -262,8 +324,8 @@ public class MandrillTemplatesApi {
 			}
 			params.put("merge_vars", vars);
 		}
-		return MandrillUtil.query(rootUrl+ "templates/render.json", 
+		return MandrillUtil.query(rootUrl+ "templates/render.json",
 				params, MandrillRenderTemplateResponse.class).getHtml();
-		
+
 	}
 }

--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillTemplate.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillTemplate.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.view;
 
@@ -11,11 +11,13 @@ import java.util.Date;
  * @since Mar 18, 2013
  */
 public class MandrillTemplate {
-	private String name, slug, code, subject, from_email, from_name, text, 
+	private String name, slug, code, subject, from_email, from_name, text,
 			publish_name, publish_code, publish_subject, publish_from_email,
 			publish_from_name, publish_text;
 	private Date published_at, created_at, updated_at;
-	
+
+	private String[] labels;
+
 	/**
 	 * @return The name of the template.
 	 */
@@ -29,51 +31,51 @@ public class MandrillTemplate {
 		return slug;
 	}
 	/**
-	 * @return The full HTML code of the template, with mc:edit 
+	 * @return The full HTML code of the template, with mc:edit
 	 * attributes marking the editable elements - draft version.
 	 */
 	public String getCode() {
 		return code;
 	}
 	/**
-	 * @return The subject line of the template, if provided 
+	 * @return The subject line of the template, if provided
 	 * &ndash; draft version.
 	 */
 	public String getSubject() {
 		return subject;
 	}
 	/**
-	 * @return The default sender address for the template, 
+	 * @return The default sender address for the template,
 	 * if provided &ndash; draft version
 	 */
 	public String getFromEmail() {
 		return from_email;
 	}
 	/**
-	 * @return The default sender from name for the template, 
+	 * @return The default sender from name for the template,
 	 * if provided &ndash; draft version
 	 */
 	public String getFromName() {
 		return from_name;
 	}
 	/**
-	 * @return The default text part of messages sent with the 
+	 * @return The default text part of messages sent with the
 	 * template, if provided &ndash; draft version
 	 */
 	public String getText() {
 		return text;
 	}
 	/**
-	 * @return The same as the template name &ndash; 
+	 * @return The same as the template name &ndash;
 	 * kept as a separate field for backwards compatibility
 	 */
 	public String getPublishName() {
 		return publish_name;
 	}
 	/**
-	 * @return The full HTML code of the template, with 
-	 * mc:edit attributes marking the editable elements 
-	 * that are available as published, if it has been 
+	 * @return The full HTML code of the template, with
+	 * mc:edit attributes marking the editable elements
+	 * that are available as published, if it has been
 	 * published.
 	 */
 	public String getPublishCode() {
@@ -98,33 +100,39 @@ public class MandrillTemplate {
 		return publish_from_name;
 	}
 	/**
-	 * @return The default text part of messages sent with the 
-	 * template, if provided. 
+	 * @return The default text part of messages sent with the
+	 * template, if provided.
 	 */
 	public String getPublishText() {
 		return publish_text;
 	}
-	
+
 	/**
-	 * @return The date and time of when this template was 
-	 * published, UTC; <code>null</code> if it has not 
+	 * @return The date and time of when this template was
+	 * published, UTC; <code>null</code> if it has not
 	 * been published.
 	 */
 	public Date getPublishedAt() {
 		return published_at;
 	}
 	/**
-	 * @return The date and time of when this template was 
+	 * @return The date and time of when this template was
 	 * created, UTC.
 	 */
 	public Date getCreatedAt() {
 		return created_at;
 	}
 	/**
-	 * @return The date and time of when this template was 
+	 * @return The date and time of when this template was
 	 * last modified, UTC.
 	 */
 	public Date getUpdatedAt() {
 		return updated_at;
+	}
+	/**
+	 * @return The labels associated with this template
+	 */
+	public String[] getLabels() {
+		return labels;
 	}
 }

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillTemplatesApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillTemplatesApiTest.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.controller;
 
@@ -20,47 +20,108 @@ import com.microtripit.mandrillapp.lutung.view.MandrillTimeSeries;
  * @since Mar 22, 2013
  */
 public final class MandrillTemplatesApiTest extends MandrillTestCase {
-	private static String templateName = 
-			"lutung_templatename_unit_test_" +System.currentTimeMillis(); 
-	
+
 	@Test(expected=MandrillApiError.class)
 	public final void testAddWithoutName() throws IOException, MandrillApiError {
-		mandrillApi.templates().add(null, 
+		mandrillApi.templates().add(null,
 				"<html><body><h1>Hello World!</h1></body></html>", null);
 		Assert.fail();
 	}
-	
+
 	@Test
 	public final void testAdd() throws IOException, MandrillApiError {
-		final MandrillTemplate t = mandrillApi.templates().add(templateName, 
+
+		String templateName = "lutung_templatename_unit_test_add1_" + System.currentTimeMillis();
+
+		final MandrillTemplate t = mandrillApi.templates().add(templateName,
 				"<html><body><h1>Hello World!</h1></body></html>", false);
 		Assert.assertNotNull(t);
 		Assert.assertNotNull(t.getName());
 		Assert.assertNotNull( mandrillApi.templates().delete(t.getName()) );
 	}
-	
+
+	@Test
+	public final void testAddWithLabels() throws IOException, MandrillApiError {
+
+		String templateName = "lutung_templatename_unit_test_add2_" + System.currentTimeMillis();
+		String label1 = "1" + System.currentTimeMillis();
+		String label2 = "2" + System.currentTimeMillis();
+		String[] labels = {label1, label2};
+
+		final MandrillTemplate t = mandrillApi.templates().add(templateName,
+				"<html><body><h1>Hello World!</h1></body></html>", false, labels);
+		Assert.assertNotNull(t);
+		Assert.assertNotNull(t.getName());
+		Assert.assertTrue(t.getLabels().length == 2);
+		Assert.assertTrue(t.getLabels()[0].equals(label1));
+		Assert.assertTrue(t.getLabels()[1].equals(label2));
+		Assert.assertNotNull( mandrillApi.templates().delete(t.getName()) );
+	}
+
 	@Test
 	public final void testList() throws IOException, MandrillApiError {
+
+		final MandrillTemplate[] startinTemplates = mandrillApi.templates().list();
+
+		String templateName1 = "lutung_templatename_unit_test_list1_1_" + System.currentTimeMillis();
+		String templateName2 = "lutung_templatename_unit_test_list1_2_" + System.currentTimeMillis();
+
+		MandrillTemplate t1 = mandrillApi.templates().add(templateName1,
+				"<html><body><h1>Hello World!</h1></body></html>", false);
+		MandrillTemplate t2 = mandrillApi.templates().add(templateName2,
+				"<html><body><h1>Hello World!</h1></body></html>", false);
+
 		final MandrillTemplate[] templates = mandrillApi.templates().list();
 		Assert.assertNotNull(templates);
-		for(MandrillTemplate t : templates) {
-			Assert.assertNotNull(t.getName());
-			Assert.assertNotNull(t.getCreatedAt());
-		}
+		Assert.assertTrue(templates.length == (startinTemplates.length + 2));
+		t1 = mandrillApi.templates().delete(t1.getName());
+		Assert.assertNotNull(t1);
+		t2 = mandrillApi.templates().delete(t2.getName());
+		Assert.assertNotNull(t2);
 	}
-	
+
+	@Test
+	public final void testListFilterByLabel() throws IOException, MandrillApiError {
+
+		String label1 = "1" + System.currentTimeMillis();
+		String label2 = "2" + System.currentTimeMillis();
+		String[] labels1 = {label1};
+		String[] labels2 = {label2};
+
+		String templateName1 = "lutung_templatename_unit_test_list2_1_" + System.currentTimeMillis();
+		String templateName2 = "lutung_templatename_unit_test_list2_2_" + System.currentTimeMillis();
+
+		MandrillTemplate t1 = mandrillApi.templates().add(templateName1,
+				"<html><body><h1>Hello World!</h1></body></html>", false, labels1);
+		MandrillTemplate t2 = mandrillApi.templates().add(templateName2,
+				"<html><body><h1>Hello World!</h1></body></html>", false, labels2);
+
+		final MandrillTemplate[] templatesFound1 = mandrillApi.templates().list(label1);
+		Assert.assertNotNull(templatesFound1);
+		Assert.assertTrue(templatesFound1.length == 1);
+
+		final MandrillTemplate[] templatesFound2 = mandrillApi.templates().list(label2);
+		Assert.assertNotNull(templatesFound2);
+		Assert.assertTrue(templatesFound2.length == 1);
+
+		t1 = mandrillApi.templates().delete(t1.getName());
+		Assert.assertNotNull(t1);
+		t2 = mandrillApi.templates().delete(t2.getName());
+		Assert.assertNotNull(t2);
+	}
+
 	@Test(expected=MandrillApiError.class)
 	public final void testInfoWithoutName() throws IOException, MandrillApiError {
 		mandrillApi.templates().info(null);
 		Assert.fail();
 	}
-	
+
 	@Test
 	public final void testInfo() throws IOException, MandrillApiError {
 		final MandrillTemplate[] templates = mandrillApi.templates().list();
 		Assert.assertNotNull(templates);
 		if(templates.length > 0) {
-			final MandrillTemplate t = 
+			final MandrillTemplate t =
 					mandrillApi.templates().info(templates[0].getName());
 			Assert.assertNotNull(t);
 			Assert.assertNotNull(t.getName());
@@ -68,23 +129,25 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 			Assert.assertNotNull(t.getCreatedAt());
 		}
 	}
-	
+
 	@Test(expected=MandrillApiError.class)
 	public final void testUpdateWithoutName() throws IOException, MandrillApiError {
-		mandrillApi.templates().update(null, 
+		mandrillApi.templates().update(null,
 				"<html><body><h1>Hello World!</h1></body></html>", false);
 		Assert.fail();
 	}
-	
+
 	@Test(expected=MandrillApiError.class)
 	public final void testUpdateWithoutCode() throws IOException, MandrillApiError {
+		String templateName = "lutung_templatename_unit_test_update1_" + System.currentTimeMillis();
 		mandrillApi.templates().update(templateName, null, false);
 		Assert.fail();
 	}
-	
+
 	@Test
 	public final void testUpdate() throws IOException, MandrillApiError {
-		MandrillTemplate t = mandrillApi.templates().add(templateName, 
+		String templateName = "lutung_templatename_unit_test_update2_" + System.currentTimeMillis();
+		MandrillTemplate t = mandrillApi.templates().add(templateName,
 				"<html><body><h1>Hello World!</h1></body></html>", false);
 		Assert.assertNotNull(t);
 		final String updatedCode = "<html><body><h1>Hello World! UPDATED</h1></body></html>";
@@ -95,19 +158,43 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 		Assert.assertNotNull(t.getCreatedAt());
 		Assert.assertNotNull( mandrillApi.templates().delete(t.getName()) );
 	}
-	
+
+	@Test
+	public final void testUpdateIncludingLabels() throws IOException, MandrillApiError {
+		String templateName = "lutung_templatename_unit_test_update3_" + System.currentTimeMillis();
+		String label1 = "1" + System.currentTimeMillis();
+		String label2 = "2" + System.currentTimeMillis();
+		String[] labels = {label1, label2};
+		MandrillTemplate t = mandrillApi.templates().add(templateName,
+				"<html><body><h1>Hello World!</h1></body></html>", false, labels);
+		Assert.assertNotNull(t);
+		final String updatedCode = "<html><body><h1>Hello World! UPDATED</h1></body></html>";
+		String label3 = "3" + System.currentTimeMillis();
+		labels[1] = label3;
+		t = mandrillApi.templates().update(t.getName(), updatedCode, false, labels);
+		Assert.assertNotNull(t);
+		Assert.assertNotNull(t.getName());
+		Assert.assertEquals(updatedCode, t.getCode());
+		Assert.assertNotNull(t.getCreatedAt());
+		Assert.assertTrue(t.getLabels().length == 2);
+		Assert.assertTrue(t.getLabels()[0].equals(label1));
+		Assert.assertTrue(t.getLabels()[1].equals(label3));
+		Assert.assertNotNull( mandrillApi.templates().delete(t.getName()) );
+	}
+
 	@Test(expected=MandrillApiError.class)
-	public final void testPublishWithoutName() 
+	public final void testPublishWithoutName()
 			throws IOException, MandrillApiError {
-		
+
 		mandrillApi.templates().publish(null);
 		Assert.fail();
 	}
-	
+
 	@Test
 	public final void testPublish() throws IOException, MandrillApiError {
+		String templateName = "lutung_templatename_unit_test_publish_" + System.currentTimeMillis();
 		MandrillTemplate t = mandrillApi.templates().add(
-				templateName, 
+				templateName,
 				"<html><body><h1>Hello World!</h1></body></html>",
 				false);
 		Assert.assertNotNull(t);
@@ -117,42 +204,43 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 		Assert.assertNotNull(t.getPublishedAt());
 		Assert.assertNotNull( mandrillApi.templates().delete(t.getName()) );
 	}
-	
+
 	@Test(expected=MandrillApiError.class)
-	public final void testDeleteWithoutName() 
+	public final void testDeleteWithoutName()
 			throws IOException, MandrillApiError {
-		
+
 		mandrillApi.templates().delete(null);
 		Assert.fail();
 	}
-	
+
 	@Test
 	public final void testDelete() throws IOException, MandrillApiError {
+		String templateName = "lutung_templatename_unit_test_delete_" + System.currentTimeMillis();
 		MandrillTemplate t = mandrillApi.templates().add(
-				templateName, 
+				templateName,
 				"<html><body><h1>Hello World!</h1></body></html>",
 				false);
 		Assert.assertNotNull(t);
 		t = mandrillApi.templates().delete(t.getName());
 		Assert.assertNotNull(t);
 	}
-	
+
 	@Test(expected=MandrillApiError.class)
-	public final void testTimeSeriesWithoutName() 
+	public final void testTimeSeriesWithoutName()
 			throws IOException, MandrillApiError {
-		
+
 		mandrillApi.templates().timeSeries(null);
 		Assert.fail();
 	}
-	
+
 	@Test
-	public final void testTimeSeries() 
+	public final void testTimeSeries()
 			throws IOException, MandrillApiError {
-		
+
 		final MandrillTemplate[] templates = mandrillApi.templates().list();
 		Assert.assertNotNull(templates);
 		if(templates.length > 0) {
-			final MandrillTimeSeries[] series = 
+			final MandrillTimeSeries[] series =
 					mandrillApi.templates().timeSeries(templates[0].getName());
 			Assert.assertNotNull(series);
 			for(MandrillTimeSeries t : series) {
@@ -160,32 +248,33 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 			}
 		}
 	}
-	
+
 	@Test(expected=MandrillApiError.class)
 	public final void testRenderWithoutName()
 			throws IOException, MandrillApiError {
-		
+
 		mandrillApi.templates().render(
-				null, 
-				new HashMap<String,String>(), 
+				null,
+				new HashMap<String,String>(),
 				null);
 		Assert.fail();
-		
+
 	}
-	
+
 	@Test(expected=MandrillApiError.class)
 	public final void testRenderWithoutContent()
 			throws IOException, MandrillApiError {
-		
+		String templateName = "lutung_templatename_unit_test_render1_" + System.currentTimeMillis();
 		mandrillApi.templates().render(templateName, null, null);
 		Assert.fail();
-		
+
 	}
-	
+
 	@Test
 	public final void testRender() throws IOException, MandrillApiError {
 		final String code = "<html><body><h1>Hello *|MERGE1|*!</h1></body></html>";
-		MandrillTemplate t = mandrillApi.templates().add(templateName, 
+		String templateName = "lutung_templatename_unit_test_render2_" + System.currentTimeMillis();
+		MandrillTemplate t = mandrillApi.templates().add(templateName,
 				code, false);
 		Assert.assertNotNull(t);
 		final HashMap<String, String> content = new HashMap<String,String>();
@@ -197,6 +286,8 @@ public final class MandrillTemplatesApiTest extends MandrillTestCase {
 				t.getName(), content, mergeVars);
 		Assert.assertNotNull(rendered);
 		Assert.assertEquals(code.replace("*|MERGE1|*", "Lutung"), rendered);
+		t = mandrillApi.templates().delete(t.getName());
+		Assert.assertNotNull(t);
 	}
-	
+
 }


### PR DESCRIPTION
Hello,

I work for a small company that has been using your MandrillAPI vor working with Mandrill EmailTemplates.  
We needed a way to filter them; to use a single account for multiple deployments of code.

I added support and tests to allow:
- creation of template with labels
- updating templates with new labels
- listing templates filtered by label (I wish I could have added more labels to filter by but Mandrill doens't support it)

I added tests and I hope you don't mind that I edited some of yours too.

Kind regards and thanks for putting this code out there,


RHodeidra