### PR TITLE
HTTPClient usage improvement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.2.3</version>
+            <version>4.3.3</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillUtil.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/controller/MandrillUtil.java
@@ -43,7 +43,7 @@ final class MandrillUtil {
 		
 		final MandrillRequest<OUT> requestModel = 
 				new MandrillRequest<OUT>(url, params, responseType);
-		return MandrillRequestDispatcher.execute(requestModel, null);
+		return MandrillRequestDispatcher.execute(requestModel);
 		
 	}
 }

--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequest.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequest.java
@@ -58,19 +58,17 @@ public final class MandrillRequest<OUT> implements RequestModel<OUT> {
 		return (httpResponseStatus == 200);
 	}
 
-	public final OUT handleResponse(final InputStream is) 
+	public final OUT handleResponse(final String responseString) 
 			throws HandleResponseException {
 		
-		String raw = null;
 		try {
-			raw = IOUtils.toString(is);
-            log.debug("raw content from response:\n" +raw);
+            log.debug("raw content from response:\n" +responseString);
 			return LutungGsonUtils.getGson().fromJson(
-					raw, responseContentType);
+					responseString, responseContentType);
 			
 		} catch(final Throwable t) {
 			String msg = "Error handling Mandrill response " +
-					((raw != null)?": '"+raw+"'" : "");
+					((responseString != null)?": '"+responseString+"'" : "");
 			throw new HandleResponseException(msg, t);
 			
 		}

--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
@@ -3,6 +3,21 @@
  */
 package com.microtripit.mandrillapp.lutung.model;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.params.ConnRoutePNames;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+import com.microtripit.mandrillapp.lutung.logging.Logger;
+import com.microtripit.mandrillapp.lutung.logging.LoggerFactory;
+import com.microtripit.mandrillapp.lutung.model.MandrillApiError.MandrillError;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -10,22 +25,6 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.URI;
 import java.util.List;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
-import org.apache.http.HttpResponse;
-import org.apache.http.StatusLine;
-import org.apache.http.client.HttpClient;
-import org.apache.http.conn.params.ConnRoutePNames;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.params.CoreProtocolPNames;
-import org.apache.http.params.HttpConnectionParams;
-
-import com.google.gson.JsonSyntaxException;
-import com.microtripit.mandrillapp.lutung.logging.Logger;
-import com.microtripit.mandrillapp.lutung.logging.LoggerFactory;
-import com.microtripit.mandrillapp.lutung.model.MandrillApiError.MandrillError;
 
 /**
  * @author rschreijer
@@ -49,33 +48,44 @@ public final class MandrillRequestDispatcher {
 	 * The value is expressed in milliseconds.
 	 * */
 	public static int CONNECTION_TIMEOUT_MILLIS = 0;
+	
+	
+	private static CloseableHttpClient httpClient;
+	private static PoolingHttpClientConnectionManager connexionManager;
+	private static RequestConfig defaultRequestConfig;
 
-	public static final <T> T execute(final RequestModel<T> requestModel,
-			HttpClient client) throws MandrillApiError, IOException {
+	static {
+		connexionManager = new PoolingHttpClientConnectionManager();
+		connexionManager.setDefaultMaxPerRoute(50);
+		defaultRequestConfig = RequestConfig.custom()
+				.setSocketTimeout(SOCKET_TIMEOUT_MILLIS)
+				.setConnectTimeout(CONNECTION_TIMEOUT_MILLIS)
+				.setConnectionRequestTimeout(CONNECTION_TIMEOUT_MILLIS).build();
+		httpClient = HttpClients.custom().setUserAgent("/Lutung-0.1")
+				.setDefaultRequestConfig(defaultRequestConfig)
+				.setConnectionManager(connexionManager).useSystemProperties()
+				.build();
+	}
+
+	public static final <T> T execute(final RequestModel<T> requestModel) throws MandrillApiError, IOException {
 
 		HttpResponse response = null;
 		InputStream responseInputStream = null;
 		try {
-			if(client == null) {
-				log.debug("Using new instance of default http client");
-				client = new DefaultHttpClient();
-				client.getParams().setParameter(
-						CoreProtocolPNames.USER_AGENT, 
-						client.getParams().getParameter(CoreProtocolPNames.USER_AGENT)+ "/Lutung-0.1");
-                // use proxy?
-                final ProxyData proxyData = detectProxyServer(requestModel.getUrl());
-                if(proxyData != null) {
-                    if(log.isDebugEnabled()) {
-                        log.debug(String.format("Using proxy @" +proxyData.host+ ":"+String.valueOf(proxyData.port)));
-                    }
-                    final HttpHost proxy = new HttpHost(proxyData.host, proxyData.port);
-                    client.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
-                }
-				HttpConnectionParams.setSoTimeout(client.getParams(), SOCKET_TIMEOUT_MILLIS);
-				HttpConnectionParams.setConnectionTimeout(client.getParams(), CONNECTION_TIMEOUT_MILLIS);
+			// use proxy?
+			final ProxyData proxyData = detectProxyServer(requestModel.getUrl());
+			if (proxyData != null) {
+				if (log.isDebugEnabled()) {
+					log.debug(String.format("Using proxy @" + proxyData.host
+							+ ":" + String.valueOf(proxyData.port)));
+				}
+				final HttpHost proxy = new HttpHost(proxyData.host,
+						proxyData.port);
+				httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY,
+						proxy);
 			}
             log.debug("starting request '" +requestModel.getUrl()+ "'");
-			response = client.execute( requestModel.getRequest() );
+			response = httpClient.execute( requestModel.getRequest() );
 			final StatusLine status = response.getStatusLine();
 			responseInputStream = response.getEntity().getContent();
 			if( requestModel.validateResponseStatus(status.getStatusCode()) ) {

--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/RequestModel.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/RequestModel.java
@@ -42,10 +42,10 @@ public interface RequestModel<V> {
 	/**
 	 * <p>Parses the content/data of this request's response into
 	 * a desired format {@link V}.
-	 * @param is
+	 * @param responseString
 	 * @return
 	 * @throws HandleResponseException
 	 */
-	public V handleResponse(InputStream is) throws HandleResponseException;
+	public V handleResponse(String responseString) throws HandleResponseException;
 	
 }


### PR DESCRIPTION
The goal of this PR is to :
* Use a more recent version of Apache HTTP client
* Use a pool of HTTPClient instead of instantiating a new DefaultHTTPClient at each request
* Get the response from Mandrill API as a String instead of InputSteam 
* Simplify how the response entity is consumed.