### PR TITLE
Gson, serialize all properties even if the're null

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/LutungGsonUtils.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/LutungGsonUtils.java
@@ -41,6 +41,7 @@ public final class LutungGsonUtils {
 	
 	public static final GsonBuilder createGsonBuilder() {
 		return new GsonBuilder()
+				.serializeNulls()
 				.setDateFormat(dateFormatStr)
 				.registerTypeAdapter(Date.class, new DateDeserializer())
 				.registerTypeAdapter(Map.class, new MapSerializer())


### PR DESCRIPTION
The #each helper in the mandrill template gets the value from the old iteration when the current value is null.
This behavior can be worked around if the null values are also serialized in the GSON parser.