### PR TITLE
Extend smtp info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,17 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.mandrillapp.wrapper.lutung</groupId>
+    <groupId>com.postex.lutung</groupId>
     <artifactId>lutung</artifactId>
-    <version>0.0.8-SNAPSHOT</version>
+    <version>0.0.1</version>
     <name>lutung</name>
     <description>Mandrill API Client for Java</description>
     <url>https://github.com/rschreijer/lutung</url>
-    <inceptionYear>2013</inceptionYear>
-    <organization>
-        <name>Microtrip.it</name>
-        <url>http://www.microtrip.it</url>
-    </organization>
     <packaging>jar</packaging>
     <licenses>
         <license>
@@ -28,11 +23,6 @@
             <email>yukyuk@gmx.com</email>
         </developer>
     </developers>
-	<parent>
-		<groupId>org.sonatype.oss</groupId>
-		<artifactId>oss-parent</artifactId>
-		<version>7</version>
-	</parent>
 
     <properties>
         <java-version>1.6</java-version>
@@ -40,11 +30,6 @@
     </properties>
 
     <!-- Scm release info -->
-    <scm>
-        <connection>scm:git:git://github.com/rschreijer/lutung.git</connection>
-        <developerConnection>scm:git:git@github.com:rschreijer/lutung.git</developerConnection>
-        <url>http://github.com/rschreijer/lutung</url>
-    </scm>
 
     <build>
         <plugins>

--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessageInfo.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessageInfo.java
@@ -140,8 +140,8 @@ public class MandrillMessageInfo {
 	}
 
 	public static class SMTPEvent {
-		private Integer ts;
-		private String type, diag;
+		private Integer ts, size;
+		private String type, diag, source_ip, destination_ip;
 
 		/**
 		 * @return The Unix timestamp when the event occured.
@@ -160,6 +160,24 @@ public class MandrillMessageInfo {
 		 */
 		public final String getDiag() {
 			return diag;
+		}
+		/**
+		 * @return The sender's IP address.
+		 */
+		public final String getSourceIp() {
+			return source_ip;
+		}
+		/**
+		 * @return The recipient's IP address.
+		 */
+		public final String getDestinationIp() {
+			return destination_ip;
+		}
+		/**
+		 * @return The SMTP response from the recipient's server.
+		 */
+		public final int getSize() {
+			return size;
 		}
 
 

--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessageInfo.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessageInfo.java
@@ -174,7 +174,7 @@ public class MandrillMessageInfo {
 			return destination_ip;
 		}
 		/**
-		 * @return The SMTP response from the recipient's server.
+		 * @return The size of event.
 		 */
 		public final int getSize() {
 			return size;


### PR DESCRIPTION
The SMTP events returned in the info call to Mandrill, are added to the MandrillMessageInfo object.