### PR TITLE
#83: Fixed error handling when send request fails with an exception.

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
@@ -1,9 +1,8 @@
 /**
- * 
+ *
  */
 package com.microtripit.mandrillapp.lutung.model;
 
-import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
@@ -19,7 +18,6 @@ import com.microtripit.mandrillapp.lutung.logging.LoggerFactory;
 import com.microtripit.mandrillapp.lutung.model.MandrillApiError.MandrillError;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.ProxySelector;
@@ -48,8 +46,8 @@ public final class MandrillRequestDispatcher {
 	 * The value is expressed in milliseconds.
 	 * */
 	public static int CONNECTION_TIMEOUT_MILLIS = 0;
-	
-	
+
+
 	private static CloseableHttpClient httpClient;
 	private static PoolingHttpClientConnectionManager connexionManager;
 	private static RequestConfig defaultRequestConfig;
@@ -70,7 +68,7 @@ public final class MandrillRequestDispatcher {
 	public static final <T> T execute(final RequestModel<T> requestModel) throws MandrillApiError, IOException {
 
 		HttpResponse response = null;
-		String responseString = null;
+		String responseString;
 		try {
 			// use proxy?
 			final ProxyData proxyData = detectProxyServer(requestModel.getUrl());
@@ -91,17 +89,17 @@ public final class MandrillRequestDispatcher {
 			if( requestModel.validateResponseStatus(status.getStatusCode()) ) {
 				try {
 					return requestModel.handleResponse( responseString );
-					
+
 				} catch(final HandleResponseException e) {
 					throw new IOException(
-							"Failed to parse response from request '" 
+							"Failed to parse response from request '"
 							+requestModel.getUrl()+ "'", e);
-					
+
 				}
-				
+
 			} else {
 				// ==> compile mandrill error!
-				MandrillError error = null;
+				MandrillError error;
 				try {
 				    error = LutungGsonUtils.getGson()
 						.fromJson(responseString, MandrillError.class);
@@ -113,18 +111,15 @@ public final class MandrillRequestDispatcher {
 				}
 
 				throw new MandrillApiError(
-						"Unexpected http status in response: " 
-						+status.getStatusCode()+ " (" 
+						"Unexpected http status in response: "
+						+status.getStatusCode()+ " ("
 						+status.getReasonPhrase()+ ")").withError(error);
-				
+
 			}
-				
+
 		} finally {
-			try {
-				EntityUtils.consume(response.getEntity());
-			} catch (IOException e) {
-				log.error("Error consuming entity", e);
-				throw e;
+			if (null != response) {
+				EntityUtils.consumeQuietly(response.getEntity());
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #83 by 
- checking if response is null first
- consuming the response entity quietly to avoid any new exception in the finally block which would hide the original exception.