### PR TITLE
#89 Fixing deserialisation of raw message parsed response

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/LutungGsonUtils.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/LutungGsonUtils.java
@@ -13,6 +13,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+import com.microtripit.mandrillapp.lutung.view.MandrillHeaderValue;
 import com.microtripit.mandrillapp.lutung.view.MandrillMessage;
 
 import java.lang.reflect.Type;
@@ -45,7 +46,9 @@ public final class LutungGsonUtils {
 				.registerTypeAdapter(Date.class, new DateDeserializer())
 				.registerTypeAdapter(Map.class, new MapSerializer())
                 .registerTypeAdapter(MandrillMessage.Recipient.Type.class,
-                		new RecipientTypeSerializer());
+						new RecipientTypeSerializer())
+				.registerTypeAdapter(MandrillHeaderValue.class,
+						new MandrillHeaderValueDeserializer());
 	}
 
 	public static final class DateDeserializer
@@ -134,4 +137,26 @@ public final class LutungGsonUtils {
 			return new JsonPrimitive(src.name().toLowerCase());
 		}
 	}
+
+	public static class MandrillHeaderValueDeserializer
+			implements JsonDeserializer<MandrillHeaderValue> {
+
+		@Override
+		public MandrillHeaderValue deserialize(
+				final JsonElement jsonElement,
+				final Type type,
+				final JsonDeserializationContext context)
+						throws JsonParseException {
+
+			if (jsonElement.isJsonArray()) {
+				return new MandrillHeaderValue(
+						(String[]) context.deserialize(jsonElement, String[].class));
+			}
+			else {
+				return new MandrillHeaderValue(jsonElement.getAsString());
+			}
+		}
+
+	}
+
 }

--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillHeaderValue.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillHeaderValue.java
@@ -1,0 +1,38 @@
+package com.microtripit.mandrillapp.lutung.view;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class MandrillHeaderValue {
+
+    private List<String> values;
+
+    public MandrillHeaderValue(List<String> values) {
+        this.values = values;
+    }
+
+    public MandrillHeaderValue(String... values) {
+        this.values = Arrays.asList(values);
+    }
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public String getFirstValue() {
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+
+        return values.get(0);
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+
+    public void setValues(String... value) {
+        this.values = Arrays.asList(value);
+    }
+
+}

--- a/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessage.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/view/MandrillMessage.java
@@ -4,6 +4,7 @@
 package com.microtripit.mandrillapp.lutung.view;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -15,7 +16,7 @@ import java.util.Map;
 public class MandrillMessage {
 	private String subject, html, text, from_email, from_name;
 	private List<Recipient> to;
-	private Map<String,String> headers;
+	private Map<String,MandrillHeaderValue> headers;
 	private Boolean important, track_opens, track_clicks, auto_text, auto_html, 
 			inline_css, url_strip_qs, preserve_recipients, view_content_link;
 	private String bcc_address, tracking_domain, signing_domain, 
@@ -120,11 +121,30 @@ public class MandrillMessage {
 	}
 	
 	/**
+	 * Returns the headers. If a header has multople values
+	 * the first value is returned. If you require both
+	 * values see {@link #getHeadersWithMultipleValuesSupport}
+	 *
 	 * @return Optional extra headers to add to the 
 	 * message (currently only Reply-To and X-* headers 
 	 * are allowed).
 	 */
 	public Map<String,String> getHeaders() {
+		Map<String, String> firstValueHeaders = new HashMap<String, String>();
+
+		for (String key : headers.keySet()) {
+			firstValueHeaders.put(key, headers.get(key).getFirstValue());
+		}
+
+		return firstValueHeaders;
+	}
+
+	/**
+	 * @return Optional extra headers to add to the
+	 * message (currently only Reply-To and X-* headers
+	 * are allowed).
+	 */
+	public Map<String,MandrillHeaderValue> getHeadersWithMultipleValuesSupport() {
 		return headers;
 	}
 
@@ -134,6 +154,21 @@ public class MandrillMessage {
 	 * are allowed)
 	 */
 	public void setHeaders(final Map<String,String> headers) {
+		Map<String, MandrillHeaderValue> multiValueHeaders = new HashMap<String, MandrillHeaderValue>();
+
+		for (String key : headers.keySet()) {
+			multiValueHeaders.put(key, new MandrillHeaderValue());
+		}
+
+		setHeadersWithMultipleValuesSupport(multiValueHeaders);
+	}
+
+	/**
+	 * @param headers Optional extra headers to add to the
+	 * message (currently only Reply-To and X-* headers
+	 * are allowed)
+	 */
+	public void setHeadersWithMultipleValuesSupport(final Map<String,MandrillHeaderValue> headers) {
 		this.headers = headers;
 	}
 

--- a/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApiTest.java
+++ b/src/test/java/com/microtripit/mandrillapp/lutung/controller/MandrillMessagesApiTest.java
@@ -173,6 +173,20 @@ public final class MandrillMessagesApiTest extends MandrillTestCase {
 		MandrillMessage parsedMessage = mandrillApi.messages().parse(null);
 		Assert.fail();
 	}
+
+	@Test
+	public void testParse03_mutlipleValuesForSingleHeader() throws IOException, MandrillApiError {
+		String testUnparsedMsg =
+			"Return-Path: <me@googlemail.com>\n" +
+			"Received: from mail47.google.com\n" +
+			"Received: by mail47.google.com with SMTP id 123\n" +
+			"To: " + mailToAddress()+ "\n" +
+			"Subject: Lutung test subject\n\n" +
+			"Sup mandrill !";
+		MandrillMessage parsedMessage = mandrillApi.messages().parse(testUnparsedMsg);
+		Assume.assumeNotNull(parsedMessage);
+		Assert.assertEquals("Lutung test subject", parsedMessage.getSubject());
+	}
 	
 	@Test
 	public void testSmtpInfoResponse() {


### PR DESCRIPTION
Support deserialising MandrillMessage where duplicate headers are present.

Fixes #89. 