### PR TITLE
Needed to get around Mandrill 307 Temporary Redirect Issue.

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
@@ -11,6 +11,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
 
@@ -62,6 +63,7 @@ public final class MandrillRequestDispatcher {
 				.setConnectTimeout(CONNECTION_TIMEOUT_MILLIS)
 				.setConnectionRequestTimeout(CONNECTION_TIMEOUT_MILLIS).build();
 		httpClient = HttpClients.custom().setUserAgent("/Lutung-0.1")
+				.setRedirectStrategy(new LaxRedirectStrategy())
 				.setDefaultRequestConfig(defaultRequestConfig)
 				.setConnectionManager(connexionManager).useSystemProperties()
 				.build();


### PR DESCRIPTION
Consistently getting a 307 error for OpenDNS for the certificates in cacerts. Adding this eliminates the issue.
It would be better to make this configurable in the future.
Without this POST will not succeed as only GET processes redirects.