### PR TITLE
Adds org.apache.httpcompoments.httpcore to pom.xml dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
 
     <properties>
         <java-version>1.6</java-version>
+		<org.apache.httpcomponents.version>4.5.3</org.apache.httpcomponents.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -155,7 +156,21 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>${org.apache.httpcomponents.version}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+		
+		<!-- Apache Http Core -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>${org.apache.httpcomponents.version}</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Lutung uses dependencies from org.apache.httpcomponents.`httpcore`, however so far only the `httpclient` library is listed in the pom.xml file as a dependency. This merge request intends to list the `httpcore` library as an explicit dependency.of Lutung.


An example usage of an entitiy that depends on the `httpcore` package can be found for example in the file  [MandrillRequestDispatcher.java](https://github.com/rschreijer/lutung/blob/master/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java) where [`org.apache.http.HttpEntity`](https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/HttpEntity.html) is being imported.