### PR TITLE
MandrillRequestDispatcher.execute throwing NPE #88

### DIFF
--- a/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
+++ b/src/main/java/com/microtripit/mandrillapp/lutung/model/MandrillRequestDispatcher.java
@@ -10,6 +10,7 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
@@ -81,8 +82,14 @@ public final class MandrillRequestDispatcher {
 				}
 				final HttpHost proxy = new HttpHost(proxyData.host,
 						proxyData.port);
-				httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY,
-						proxy);
+
+				RequestConfig requestConfig = RequestConfig.custom()
+						.setProxy(proxy).build();
+
+				httpClient = HttpClients.custom().setUserAgent("/Lutung-0.1")
+						.setDefaultRequestConfig(requestConfig)
+						.setConnectionManager(connexionManager).useSystemProperties()
+						.build();
 			}
             log.debug("starting request '" +requestModel.getUrl()+ "'");
 			response = httpClient.execute( requestModel.getRequest() );


### PR DESCRIPTION
httpClient.getParams() being deprecated, adding http.proxy breaks flow with a NullPointerException. 

**Steps to reproduce**

Build a java application using library version 0.0.8 and set proxy -Dhttp.proxyHost=<>  Dhttp.proxyPort=<>  in vm args 

**Issue:**

java.lang.NullPointerException: null
	at com.microtripit.mandrillapp.lutung.model.MandrillRequestDispatcher.execute(MandrillRequestDispatcher.java:124) ~[lutung-0.0.8.jar!/:na]
	at com.microtripit.mandrillapp.lutung.controller.MandrillUtil.query(MandrillUtil.java:44) ~[lutung-0.0.8.jar!/:na]
	at com.microtripit.mandrillapp.lutung.controller.MandrillMessagesApi.send(MandrillMessagesApi.java:100) ~[lutung-0.0.8.jar!/:na]
	at com.microtripit.mandrillapp.lutung.controller.MandrillMessagesApi.send(MandrillMessagesApi.java:55) ~[lutung-0.0.8.jar!/:na]

**Fix:** 

Build the httpClient using the recommended 'RequestConfig' way of setting the proxy host.